### PR TITLE
docs: add UPGRADING.md with v2.0 breaking changes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,10 +44,9 @@ changes.
   tpuf.namespace("ns").branch_from(source_namespace: "src")
   ```
 
-- The `encryption` parameter has been restructured. The `cmek` wrapper has been
-  removed in favor of a flat hash with a required `mode` discriminator. A new
-  `{ mode: :default }` variant lets you explicitly opt out of CMEK on writes to
-  a CMEK-enabled namespace.
+- The `encryption` parameter has been restructured. A new `{ mode: :default }`
+  variant lets you explicitly opt out of CMEK on writes to a CMEK-enabled
+  namespace.
 
   Old:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,29 @@ changes.
   tpuf.namespace("ns").branch_from(source_namespace: "src")
   ```
 
+- The `encryption` parameter has been restructured. The `cmek` wrapper has been
+  removed in favor of a flat hash with a required `mode` discriminator. A new
+  `{ mode: :default }` variant lets you explicitly opt out of CMEK on writes to
+  a CMEK-enabled namespace.
+
+  Old:
+
+  ```rb
+  tpuf.namespace("ns").write(
+    upsert_rows: [...],
+    encryption: { cmek: { key_name: "..." } },
+  )
+  ```
+
+  New:
+
+  ```rb
+  tpuf.namespace("ns").write(
+    upsert_rows: [...],
+    encryption: { mode: "customer-managed", key_name: "..." },
+  )
+  ```
+
 ## v1.0
 
 No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,29 @@ changes.
 
 ## v2.0
 
+- The `encryption` parameter has been restructured.
+
+  Old:
+
+  ```rb
+  tpuf.namespace("ns").write(
+    upsert_rows: [...],
+    encryption: { cmek: { key_name: "..." } },
+  )
+  ```
+
+  New:
+
+  ```rb
+  tpuf.namespace("ns").write(
+    upsert_rows: [...],
+    encryption: { mode: "customer-managed", key_name: "..." },
+  )
+  ```
+
+  A new `{ mode: :default }` variant lets you migrate a namespace from CMEK
+  to default encryption.
+
 - The `copy_from_namespace` parameter to the `write` method has been replaced
   with a dedicated `copy_from` method.
 
@@ -43,26 +66,3 @@ changes.
   ```rb
   tpuf.namespace("ns").branch_from(source_namespace: "src")
   ```
-
-- The `encryption` parameter has been restructured.
-
-  Old:
-
-  ```rb
-  tpuf.namespace("ns").write(
-    upsert_rows: [...],
-    encryption: { cmek: { key_name: "..." } },
-  )
-  ```
-
-  New:
-
-  ```rb
-  tpuf.namespace("ns").write(
-    upsert_rows: [...],
-    encryption: { mode: "customer-managed", key_name: "..." },
-  )
-  ```
-
-  A new `{ mode: :default }` variant lets you migrate a namespace from CMEK
-  to default encryption.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,9 +44,7 @@ changes.
   tpuf.namespace("ns").branch_from(source_namespace: "src")
   ```
 
-- The `encryption` parameter has been restructured. A new `{ mode: :default }`
-  variant lets you explicitly opt out of CMEK on writes to a CMEK-enabled
-  namespace.
+- The `encryption` parameter has been restructured.
 
   Old:
 
@@ -65,6 +63,9 @@ changes.
     encryption: { mode: "customer-managed", key_name: "..." },
   )
   ```
+
+  A new `{ mode: :default }` variant lets you explicitly opt out of CMEK on
+  writes to a CMEK-enabled namespace.
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,5 +64,5 @@ changes.
   )
   ```
 
-  A new `{ mode: :default }` variant lets you explicitly opt out of CMEK on
-  writes to a CMEK-enabled namespace.
+  A new `{ mode: :default }` variant lets you migrate a namespace from CMEK
+  to default encryption.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -66,7 +66,3 @@ changes.
 
   A new `{ mode: :default }` variant lets you explicitly opt out of CMEK on
   writes to a CMEK-enabled namespace.
-
-## v1.0
-
-No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,49 @@
+# Upgrade guide
+
+This document describes the notable breaking changes, if any, in each version of
+the Ruby client. See [CHANGELOG.md](./CHANGELOG.md) for a comprehensive list of
+changes.
+
+## v2.0
+
+- The `copy_from_namespace` parameter to the `write` method has been replaced
+  with a dedicated `copy_from` method.
+
+  Old:
+
+  ```rb
+  tpuf.namespace("ns").write(
+    copy_from_namespace: {
+      source_namespace: "src",
+      source_region: "gcp-us-central1",
+    },
+  )
+  ```
+
+  New:
+
+  ```rb
+  tpuf.namespace("ns").copy_from(
+    source_namespace: "src",
+    source_region: "gcp-us-central1",
+  )
+  ```
+
+- The `branch_from_namespace` parameter to the `write` method has been replaced
+  with a dedicated `branch_from` method.
+
+  Old:
+
+  ```rb
+  tpuf.namespace("ns").write(branch_from_namespace: "src")
+  ```
+
+  New:
+
+  ```rb
+  tpuf.namespace("ns").branch_from(source_namespace: "src")
+  ```
+
+## v1.0
+
+No significant changes.


### PR DESCRIPTION
Adds an UPGRADING.md modeled after the Python and TypeScript clients. Documents the v2.0 breaking changes inferred from the docs samples:

- `copy_from_namespace` write parameter replaced by a dedicated `copy_from` method.
- `branch_from_namespace` write parameter replaced by a dedicated `branch_from` method.

Also adds a stub v1.0 entry noting no significant changes.